### PR TITLE
fix #53

### DIFF
--- a/manuscript.Rmd
+++ b/manuscript.Rmd
@@ -625,7 +625,7 @@ A preregistration, together with version control, allows their readers to inform
 ### Preregistration as Code
 
 Currently, there are various templates available that guide researchers in developing data analysis plans for preregistration [@osfstandard; @socpsytemp; @howtoreplicate]. 
-Still, with any natural-language representation of an analysis plan, there remains ambiguity when turning the natural language description of a given data analysis into code.
+Still, with any natural-language representation of an analysis plan, there remains ambiguity when turning the natural language description of a given data analysis into code [@sep-ambiguity].
 Here, we discuss preregistration as code (PAC) with the R package repro, which leaves no room for ambiguity.
 PAC essentially reverses the process of empirical research.
 Before researchers gather data, they write a reproducible, dynamically generated manuscript including the sections Introduction, Methods, and Results---initially based on simulated data.

--- a/references.bib
+++ b/references.bib
@@ -673,3 +673,14 @@ eprint = {
   note = {R package version 0.4.2},
   url = {https://CRAN.R-project.org/package=vitae},
 }
+
+@InCollection{sep-ambiguity,
+	author       =	{Sennet, Adam},
+	title        =	{{Ambiguity}},
+	booktitle    =	{The {Stanford} Encyclopedia of Philosophy},
+	editor       =	{Edward N. Zalta},
+	howpublished =	{\url{https://plato.stanford.edu/archives/spr2016/entries/ambiguity/}},
+	year         =	{2016},
+	edition      =	{{S}pring 2016},
+	publisher    =	{Metaphysics Research Lab, Stanford University}
+}


### PR DESCRIPTION
I cited the stanford encyclopedia about the ambiguity of natural language. It is not specifically about turning natural language into code.